### PR TITLE
Update sonar-maven-plugin

### DIFF
--- a/sputnik/pom.xml
+++ b/sputnik/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
-            <version>3.4.0</version>
+            <version>3.4.0.905</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>

--- a/sputnik/pom.xml
+++ b/sputnik/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>


### PR DESCRIPTION
sonar-maven-plugin 3.0.1 is not compatible with sonarqube 6.7: org/sonar/batch/bootstrapper/IssueListener e.g. is missing there.

```
[ERROR] Failed to execute goal de.mirkosertic.mavensonarsputnik:sputnik:1.7:sputnik (default-cli) on project parent: Execution default-cli of goal de.mirkosertic.mavensonarsputnik:sputnik:1.7:sputnik failed: A required class was missing while executing de.mirkosertic.mavensonarsputnik:sputnik:1.7:sputnik: org/sonar/batch/bootstrapper/IssueListener
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>de.mirkosertic.mavensonarsputnik:sputnik:1.7
```